### PR TITLE
Add tests for the metaprogramming methods on the Entity base class

### DIFF
--- a/lib/open_dota_api/entities/instantiable.rb
+++ b/lib/open_dota_api/entities/instantiable.rb
@@ -8,8 +8,8 @@ module OpenDotaApi
       module ClassMethods
         def instantiate(data)
           return new(data) if data.respond_to?(:keys)
-
-          data.map { |data_instance| new(data_instance) }
+          return data.map { |data_instance| new(data_instance) } if data.respond_to?(:map)
+          raise ArgumentError.new "data passed to instantiate must be a hash or an array"
         end
       end
     end

--- a/lib/open_dota_api/entities/instantiable.rb
+++ b/lib/open_dota_api/entities/instantiable.rb
@@ -8,8 +8,10 @@ module OpenDotaApi
       module ClassMethods
         def instantiate(data)
           return new(data) if data.respond_to?(:keys)
+
           return data.map { |data_instance| new(data_instance) } if data.respond_to?(:map)
-          raise ArgumentError.new "data passed to instantiate must be a hash or an array"
+
+          raise ArgumentError, 'data passed to instantiate must be a hash or an array'
         end
       end
     end

--- a/spec/lib/open_dota_api/entities/instantiable_spec.rb
+++ b/spec/lib/open_dota_api/entities/instantiable_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+class InstantiableClass
+  include OpenDotaApi::Entities::Instantiatable
+
+  attr_accessor :data
+
+  def initialize(data)
+    @data = data
+  end
+end
+
+describe InstantiableClass do
+  it { expect(described_class).to respond_to(:instantiate) }
+
+  describe ".instantiate" do
+    let(:data) { {"a" => "b" } }
+
+    subject { InstantiableClass.instantiate(data) }
+
+    it { is_expected.to be_a InstantiableClass }
+    it { is_expected.to have_attributes(data: data) }
+
+    context "when the given data does not respond to :keys" do
+      let(:data) { ["a", "b"] }
+
+      it "instantiates an instance per member of the enumerable" do
+        expect(subject).to all(be_instance_of(InstantiableClass))
+        expect(subject.map(&:data)).to eq(data)
+      end
+    end
+
+    context "when the data passed in isn't mappable" do
+      let(:data) { 1 }
+
+      it { expect { subject }.to raise_error(ArgumentError) }
+    end
+  end
+end

--- a/spec/lib/open_dota_api/entity_spec.rb
+++ b/spec/lib/open_dota_api/entity_spec.rb
@@ -1,0 +1,81 @@
+require 'spec_helper'
+
+class ChildEntity < OpenDotaApi::Entity
+  def a
+    "special datum"
+  end
+end
+
+describe OpenDotaApi::Entity do
+  let(:data) { { "very_nice": "datum" } }
+
+  subject { described_class.new(data) }
+
+  describe "initializing with a hash adds instance methods to the Entity" do
+      it { is_expected.to respond_to(:very_nice) }
+      it { expect(subject.very_nice).to eq("datum") }
+      it { is_expected.not_to respond_to(:not_nice) }
+  end
+
+  describe ".define_adder" do
+    # these tests aren't perfectly isolated. Opening the
+    # class and adding instance methods makes that method
+    # available to all objects of that class, as long as the
+    # class constant remains defined in the current scope.
+    # To fully isolate these tests, we'd need a before block
+    # that looked something like:
+    #
+    #   src_loc = OpenDotaApi.const_source_location(:Entity)
+    #   OpenDotaApi.send(:remove_const, :Entity)
+    #   Kernel.load(src_loc[0])
+    #
+    # This is pretty janky, and doesn't seem necessary, just
+    # want to preserve in case others get confused
+
+    let(:instance) { described_class.new({ "a": "a_datum" }) }
+
+    subject { instance.class.define_adder(["a"]) }
+
+    before(:each) { subject }
+
+    it "adds an instance method #a to the Entity object" do
+      expect(instance).to respond_to(:a)
+    end
+
+    it { expect(instance.a).to eq("a_datum") }
+
+    describe ChildEntity do
+      it "existing instance methods are not overridden" do
+        expect(instance.a).to eq("special datum")
+      end
+    end
+
+    it "appends instance methods for subsequently created instances" do
+      second = OpenDotaApi::Entity.new({})
+      expect(second).to respond_to(:a)
+      expect(second.a).to be_nil
+    end
+
+    it "doesn't append an instance method in the parent" do
+      subclass = ChildEntity.new({})
+      subclass.class.define_adder(["b"])
+      expect(subclass).to respond_to(:b)
+      expect(instance).not_to respond_to(:b)
+    end
+
+    it "reopens the class of already-created instances" do
+      OpenDotaApi::Entity.define_adder(["c"])
+      expect(instance).to respond_to(:c)
+    end
+  end
+
+  describe ".define_child_entity" do
+    subject { described_class.new({"child_key" => {"d": "e"} }) }
+
+    before(:each) { subject.class.define_child_entity(ChildEntity, "child_key") }
+
+    it { is_expected.to respond_to(:child_key) }
+    it { expect(subject.child_key).to be_a(ChildEntity) }
+    it { expect(subject.child_key.d).to eq "e"}
+  end
+end

--- a/spec/lib/open_dota_api/entity_spec.rb
+++ b/spec/lib/open_dota_api/entity_spec.rb
@@ -32,7 +32,7 @@ describe OpenDotaApi::Entity do
     # This is pretty janky, and doesn't seem necessary, just
     # want to preserve in case others get confused
 
-    let(:instance) { described_class.new({ "a": "a_datum" }) }
+    let(:instance) { described_class.new({ "a"=> "a_datum" }) }
 
     subject { instance.class.define_adder(["a"]) }
 
@@ -70,7 +70,7 @@ describe OpenDotaApi::Entity do
   end
 
   describe ".define_child_entity" do
-    subject { described_class.new({"child_key" => {"d": "e"} }) }
+    subject { described_class.new({"child_key" => {"d"=> "e"} }) }
 
     before(:each) { subject.class.define_child_entity(ChildEntity, "child_key") }
 

--- a/spec/lib/open_dota_api/entity_spec.rb
+++ b/spec/lib/open_dota_api/entity_spec.rb
@@ -7,14 +7,13 @@ class ChildEntity < OpenDotaApi::Entity
 end
 
 describe OpenDotaApi::Entity do
-  let(:data) { { "very_nice": "datum" } }
+  let(:data) { { "prime" => "datum" } }
 
   subject { described_class.new(data) }
 
   describe "initializing with a hash adds instance methods to the Entity" do
-      it { is_expected.to respond_to(:very_nice) }
-      it { expect(subject.very_nice).to eq("datum") }
-      it { is_expected.not_to respond_to(:not_nice) }
+      it { is_expected.to respond_to(:prime) }
+      it { expect(subject.prime).to eq("datum") }
   end
 
   describe ".define_adder" do
@@ -32,7 +31,7 @@ describe OpenDotaApi::Entity do
     # This is pretty janky, and doesn't seem necessary, just
     # want to preserve in case others get confused
 
-    let(:instance) { described_class.new({ "a"=> "a_datum" }) }
+    let(:instance) { described_class.new({ "a" => "a_datum" }) }
 
     subject { instance.class.define_adder(["a"]) }
 
@@ -70,12 +69,12 @@ describe OpenDotaApi::Entity do
   end
 
   describe ".define_child_entity" do
-    subject { described_class.new({"child_key" => {"d"=> "e"} }) }
+    subject { described_class.new({"child_key" => {"d" => "e"} }) }
 
     before(:each) { subject.class.define_child_entity(ChildEntity, "child_key") }
 
     it { is_expected.to respond_to(:child_key) }
     it { expect(subject.child_key).to be_a(ChildEntity) }
-    it { expect(subject.child_key.d).to eq "e"}
+    it { expect(subject.child_key.d).to eq("e") }
   end
 end


### PR DESCRIPTION
Adding tests for the metaprogramming methods on Entity. Discovered a minor bug so will fix that as well in this PR.